### PR TITLE
fix: serve NATpaper metadata through nginx

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -48,6 +48,26 @@ http {
             try_files $uri $uri/ =404;
         }
 
+        location = /natpaper {
+            add_header Cache-Control "no-store, no-cache";
+						add_header Strict-Transport-Security "max-age=86400; includeSubDomains";
+						add_header X-Content-Type-Options "nosniff";
+						add_header X-Frame-Options "DENY";
+						add_header X-XSS-Protection "1; mode=block";
+
+            try_files /natpaper.html =404;
+        }
+
+        location = /natpaper/ {
+            add_header Cache-Control "no-store, no-cache";
+						add_header Strict-Transport-Security "max-age=86400; includeSubDomains";
+						add_header X-Content-Type-Options "nosniff";
+						add_header X-Frame-Options "DENY";
+						add_header X-XSS-Protection "1; mode=block";
+
+            try_files /natpaper.html =404;
+        }
+
         location / {
             add_header 'Cache-Control' "public, max-age=3600";
             try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## Summary
- Adds exact nginx routes for /natpaper and /natpaper/ to serve dist/natpaper.html
- Keeps the route-specific Open Graph/Twitter metadata visible to crawlers on the Heroku nginx deployment

## Test Plan
- npm run build
- Verified production currently serves /natpaper-og-v2.jpg as image/jpeg
- Verified production /natpaper still serves root metadata before this nginx route fix