### PR TITLE
chore: schedule weekly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "10:00"
+      timezone: America/Chicago
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- add weekly npm dependency update checks
- group minor and patch updates into focused maintenance PRs
- cap concurrent dependency PRs at five

## Why
The current `js-yaml` alerts are already fixed and `main` audits clean. This configuration reduces future reactive security cleanup by keeping the lockfile and transitive dependencies current.

## Verification
- `npm audit` — 0 vulnerabilities
- `npm run build` — passed under Node 22
- `npx vue-tsc --noEmit` — passed
- Dependabot YAML parsed successfully
