### PR TITLE
Pin review apps to heroku-24, matching production

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,17 +1,17 @@
 {
-    "name": "NAT Website",
-    "description": "This web vue.js application is the website for $NAT.",
-    "website": "https://natgmi.com",
-    "repository": "https://github.com/wgomez23/bolt-vue-fgklts",
-    "logo": "https://natgmi.com/Nat_logo.png",
-    "success_url": "/",
-    "stack": "heroku-22",
-    "buildpacks": [
-      {
-        "url": "heroku/nodejs"
-      },
-      {
-        "url": "https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku-community/nginx.tgz"
-      }
-    ]
+  "name": "NAT Website",
+  "description": "This web vue.js application is the website for $NAT.",
+  "website": "https://natgmi.com",
+  "repository": "https://github.com/wgomez23/bolt-vue-fgklts",
+  "logo": "https://natgmi.com/Nat_logo.png",
+  "success_url": "/",
+  "stack": "heroku-24",
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    },
+    {
+      "url": "https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku-community/nginx.tgz"
+    }
+  ]
 }


### PR DESCRIPTION
Every new natgmi review app (natgmi-pr-41 through -45 currently) has been building on **heroku-22** because this app.json declares it, while the natgmi production app runs **heroku-24**. A review app on a different stack than production tests the platform instead of the change — native-binary differences are exactly where stacks diverge.

This is the same one-line fix applied to the NatFun-WebApp, NatFun-Front, StonkMarketClub-Front and NatFun-AIProxy app.jsons on Aug 10 (NatFun-Back d18777f); this repo was missed because it lives outside the MetaZoneio org.

The five live PR apps have already been `stack:set` to heroku-24 directly (effective on their next build) — this PR fixes the source so future review apps spawn correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDyoJKDJyVSw2VnGQq7ukL